### PR TITLE
fix vector 0.22.3 sha256 checksum

### DIFF
--- a/Formula/vector.rb
+++ b/Formula/vector.rb
@@ -3,7 +3,7 @@ class Vector < Formula
   homepage "https://github.com/timberio/vector"
   url "https://packages.timber.io/vector/0.22.3/vector-0.22.3-x86_64-apple-darwin.tar.gz"
   version "0.22.3"
-  sha256 "7ac6abdc3aea889fd8b7d428da65acc1bb539fb7334333c32758e21501392d3a"
+  sha256 "a2b928da80499de887d60092e49eae0095eda74a71dd35f879d16fae115eb7cb"
   head "https://github.com/timberio/vector.git"
 
   def install


### PR DESCRIPTION
I'm running into the same error as #6 when trying to install vector 0.22.3:

```
Error: vector: SHA256 mismatch
Expected: 7ac6abdc3aea889fd8b7d428da65acc1bb539fb7334333c32758e21501392d3a
  Actual: a2b928da80499de887d60092e49eae0095eda74a71dd35f879d16fae115eb7cb
```

I updated the checksum here the same way as in #7 after confirming manually that the output of `sha256sum` is `a2b928da80499de887d60092e49eae0095eda74a71dd35f879d16fae115eb7cb`. It looks like the checksum is different than the one mentioned in https://github.com/vectordotdev/homebrew-brew/pull/7#issuecomment-811006713

Let me know if I missed anything, thanks!