### PR TITLE
Use YAML as default config

### DIFF
--- a/Formula/vector.rb
+++ b/Formula/vector.rb
@@ -41,7 +41,7 @@ class Vector < Formula
   end
 
   service do
-    run [opt_bin/"vector", "--config", etc/"vector/vector.toml"]
+    run [opt_bin/"vector", "--config", etc/"vector/vector.yaml"]
     keep_alive false
     working_dir var
     error_log_path var/"log/vector.log"

--- a/Formula/vector.rb
+++ b/Formula/vector.rb
@@ -13,6 +13,9 @@ class Vector < Formula
     inreplace "config/vector.toml" do |s|
       s.gsub!(/data_dir = ".*"/, "data_dir = \"#{var}/lib/vector/\"")
     end
+    inreplace "config/vector.yaml" do |s|
+      s.gsub!(/data_dir: ".*"/, "data_dir: \"#{var}/lib/vector/\"")
+    end
 
     # Move config files into etc
     (etc/"vector").install Dir["config/*"]


### PR DESCRIPTION
Since TOML config is being deprecated in Vector and in `v0.34.0` it will not be used as default, it should be changed from TOML to YAML in Homebrew formula as well, right?